### PR TITLE
fix index errors when fetching a group/user that does not exist

### DIFF
--- a/libstns/stns.go
+++ b/libstns/stns.go
@@ -129,6 +129,10 @@ func (s *STNS) GetUserByName(name string) (*model.User, error) {
 		return nil, err
 	}
 
+	if len(v) == 0 {
+		return nil, errors.New("user not found")
+	}
+
 	return v[0], nil
 }
 
@@ -140,6 +144,10 @@ func (s *STNS) GetUserByID(id int) (*model.User, error) {
 	v := []*model.User{}
 	if err := json.Unmarshal(r.Body, &v); err != nil {
 		return nil, err
+	}
+
+	if len(v) == 0 {
+		return nil, errors.New("user not found")
 	}
 
 	return v[0], nil
@@ -168,6 +176,10 @@ func (s *STNS) GetGroupByName(name string) (*model.Group, error) {
 		return nil, err
 	}
 
+	if len(v) == 0 {
+		return nil, errors.New("group not found")
+	}
+
 	return v[0], nil
 }
 
@@ -179,6 +191,10 @@ func (s *STNS) GetGroupByID(id int) (*model.Group, error) {
 	v := []*model.Group{}
 	if err := json.Unmarshal(r.Body, &v); err != nil {
 		return nil, err
+	}
+
+	if len(v) == 0 {
+		return nil, errors.New("group not found")
 	}
 
 	return v[0], nil


### PR DESCRIPTION
```panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/chibiegg/libstns-go/libstns.(*STNS).GetGroupByName(0xc0001f6f60, {0xc000017710, 0x7fff7a8aed71})
	/Users/chibiegg/go/src/github.com/chibiegg/libstns-go/libstns/stns.go:171 +0x11b
```